### PR TITLE
Improve input validation and error display

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,13 +29,22 @@ def index():
 
             # Decimal-Konvertierung
             mwst = Decimal(mwst_raw)
+            if mwst < 0:
+                raise ValueError("MwSt darf nicht negativ sein.")
+            if mwst > 100:
+                raise ValueError("MwSt darf maximal 100% betragen.")
+
             if ek_netto:
                 en = Decimal(ek_netto)
                 ek_netto_val  = q2(en)
+                if ek_netto_val < 0:
+                    raise ValueError("EK Netto darf nicht negativ sein.")
                 ek_brutto_val = q2(ek_netto_val * (Decimal(1) + mwst/Decimal(100)))
             else:
                 eb = Decimal(ek_brutto)
                 ek_brutto_val = q2(eb)
+                if ek_brutto_val < 0:
+                    raise ValueError("EK Brutto darf nicht negativ sein.")
                 ek_netto_val  = q2(ek_brutto_val / (Decimal(1) + mwst/Decimal(100)))
 
             # Marge anwenden

--- a/static/style.css
+++ b/static/style.css
@@ -103,6 +103,17 @@ button[type="submit"]:hover {
   background: rgba(255,255,255,0.03);
 }
 
+/* Error */
+.error-box {
+  background: var(--result-bg);
+  color: #e53e3e;
+  padding: 1.5rem;
+  margin-top: 2rem;
+  border: 2px solid #e53e3e;
+  border-radius: 20px;
+  box-shadow: 0 0 12px rgba(0,0,0,0.15);
+}
+
 /* Credit-Box */
 .credit-box {
   position: fixed; bottom: 1rem; right: 1rem;

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,14 +35,20 @@
     </form>
 
     {% if result %}
-      <div class="result-box">
-        <h2>Ergebnis</h2>
-        <ul>
-          {% for key, value in result.items() %}
-            <li data-key="{{ key }}"><strong>{{ key }}:</strong> {{ value }}</li>
-          {% endfor %}
-        </ul>
-      </div>
+      {% if result.get('Fehler') %}
+        <div class="error-box">
+          <strong>Fehler:</strong> {{ result['Fehler'] }}
+        </div>
+      {% else %}
+        <div class="result-box">
+          <h2>Ergebnis</h2>
+          <ul>
+            {% for key, value in result.items() %}
+              <li data-key="{{ key }}"><strong>{{ key }}:</strong> {{ value }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
     {% endif %}
   </div>
 


### PR DESCRIPTION
## Summary
- validate that VAT and prices are non-negative
- show a clear error message when validation fails
- style error messages in UI

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bdf3ad170832cbdaf642514d3206b