### PR TITLE
Add pytest-based tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ services:
 
 ---
 
+## 🧪 Tests
+
+Ein rudimentäres Testset auf Basis von `pytest` liegt im Verzeichnis
+`tests/`. So kannst du es lokal ausführen:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+---
+
 ## 📄 License
 
 MIT © 2025 Panudln

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
 gunicorn==20.1.0
+pytest==8.2.1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,28 @@
+import pytest
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_get_root(client):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'Preisrechner' in resp.data
+
+def test_valid_post(client):
+    data = {
+        'ek_netto': '100',
+        'mwst': '19',
+        'aufschlag': '10',
+        'aufschlag_typ': '%'
+    }
+    resp = client.post('/', data=data)
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert '100.00 €' in html
+    assert '119.00 €' in html
+    assert '110.00 €' in html
+    assert '130.90 €' in html


### PR DESCRIPTION
## Summary
- add pytest dev requirement
- add tests for GET and POST behaviour
- document how to run tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_685bdf3bbf20832c827650d4016f2ac3