### PR TITLE
Add export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
   - EK Netto  
   - EK Brutto  
   - VK Netto (inkl. Marge)  
-  - VK Brutto (inkl. Marge)  
-- **Modernes UI**  
+  - VK Brutto (inkl. Marge)
+  - Export als PDF oder CSV
+  - **Modernes UI**
   Dark-Mode (Standard)  
 - **Container-ready**  
   Lokal mit Flask oder per Docker-Compose starten  

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
 gunicorn==20.1.0
+reportlab==3.6.12
+pytest==8.2.1

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,16 +34,21 @@
       </fieldset>
     </form>
 
-    {% if result %}
-      <div class="result-box">
-        <h2>Ergebnis</h2>
-        <ul>
-          {% for key, value in result.items() %}
-            <li data-key="{{ key }}"><strong>{{ key }}:</strong> {{ value }}</li>
-          {% endfor %}
-        </ul>
-      </div>
-    {% endif %}
+      {% if result %}
+        <div class="result-box">
+          <h2>Ergebnis</h2>
+          <ul>
+            {% for key, value in result.items() %}
+              <li data-key="{{ key }}"><strong>{{ key }}:</strong> {{ value }}</li>
+            {% endfor %}
+          </ul>
+          <p>
+            <a href="{{ url_for('export', format='pdf') }}">PDF herunterladen</a>
+            |
+            <a href="{{ url_for('export', format='csv') }}">CSV herunterladen</a>
+          </p>
+        </div>
+      {% endif %}
   </div>
 
   <!-- Credit-Box -->

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,34 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import pytest
+from app import app
+
+@pytest.fixture
+
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def calculate(client):
+    return client.post('/', data={
+        'ek_netto': '100',
+        'mwst': '19',
+        'aufschlag': '20',
+        'aufschlag_typ': '%'
+    })
+
+def test_csv_export(client):
+    calculate(client)
+    resp = client.get('/export?format=csv')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'text/csv'
+    assert b'EK Netto' in resp.data
+
+def test_pdf_export(client):
+    calculate(client)
+    resp = client.get('/export?format=pdf')
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'application/pdf'
+    assert resp.data.startswith(b'%PDF')


### PR DESCRIPTION
## Summary
- generate CSV and PDF exports for calculation results
- link to download exports in the result box
- add `reportlab` and `pytest` dependencies
- test export routes
- document export feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685be5ce3f60832c9dcb5b7ff32a345b