### PR TITLE
Add fade-in animation class

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -23,6 +23,22 @@ body.dark {
 /* Box Sizing */
 * { box-sizing: border-box; }
 
+/* Fade In Animation */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeInUp 0.6s ease-out both;
+}
+
 /* Body */
 body {
   margin: 0; padding: 0;

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,7 @@
 </head>
 <body class="dark">
   <button id="theme-toggle" class="toggle-theme">🌞</button>
-  <div class="container">
+  <div class="container fade-in">
     <h1>🧮 Preisrechner</h1>
     <form method="POST">
       <fieldset>
@@ -35,7 +35,7 @@
     </form>
 
     {% if result %}
-      <div class="result-box">
+      <div class="result-box fade-in">
         <h2>Ergebnis</h2>
         <ul>
           {% for key, value in result.items() %}
@@ -47,7 +47,7 @@
   </div>
 
   <!-- Credit-Box -->
-  <div class="credit-box">
+  <div class="credit-box fade-in">
     Made by <a href="https://github.com/Panudln" target="_blank" rel="noopener">Panudln</a>
   </div>
 


### PR DESCRIPTION
## Summary
- define `fadeInUp` keyframes and reusable `.fade-in` class
- fade container, result box and credit box in on display

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c0446f4c0832cb3c92a85e711b2c1